### PR TITLE
usability/user-story-13

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ and I am redirected to the pet index page where I no longer see this pet
 Users should be able to use the site easily. This means making sure there are links/buttons to reach all parts of the site and the styling/layout is sensible.
 
 ```
-[ ] done
+[x] done
 
 User Story 13, Shelter Update From Shelter Index Page
 

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Shelters</h1>
 
 <% @shelters.each do |shelter| %>
-  <h3><%= shelter.name %></h3>
+  <h3><%= shelter.name %><a href='shelters/<%= shelter.id %>/edit' class='btn btn-info' role='button'>Edit</a></h3>
 <% end %>
 
 <a href='shelters/new' class='btn btn-info' role='button'>Create New</a>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,3 +39,22 @@ Pet.destroy_all
                     sex:        "female",
                     status:     "adoptable",
                     shelter_id: @shelter_2.id)
+@pet_4 = Pet.create(image: "http://reptile.guide/wp-content/uploads/2019/02/Bearded-dragon-poop-.jpg",
+                    name:  'Chive',
+                    desc:  "I'm a bearded dragon. I like to hunt and be active during the daytime.",
+                    age: '5',
+                    sex: 'male',
+                    status: "pending_adoption",
+                    shetler_id: @shelter_1.id)
+@pet_5 = Pet.create(image: "https://lafeber.com/pet-birds/wp-content/uploads/2018/06/Lovebird-300x300.jpg",
+                    name: 'Charlene',
+                    age: '3',
+                    sex: 'female'
+                    status: "adoptable",
+                    shelter_id: @shelter_3.id)
+@pet_6 = Pet.create(image: "https://d17fnq9dkz9hgj.cloudfront.net/uploads/2012/11/153546296-items-dangerous-pet-birds.jpg",
+                    name: 'Zoe',
+                    age: '8',
+                    sex: 'female'
+                    status: "pending_adoption",
+                    shelter_id: @shelter_3.id)

--- a/spec/features/shelters/user_can_create_shelter_spec.rb
+++ b/spec/features/shelters/user_can_create_shelter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "shelters index page", type: :feature do
     expect(page).to have_link('Create New')
     expect(page).not_to have_content('The Aviary')
 
-    click_link
+    click_link 'Create New'
 
     expect(current_path).to eq('/shelters/new')
     expect(page).to have_button('Submit')

--- a/spec/features/usability/user_can_shelter_update_from_shelter_index_spec.rb
+++ b/spec/features/usability/user_can_shelter_update_from_shelter_index_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "shelter index page", type: :feature do
+  it "can update shelter from shelter index page" do
+    shelter_1 = Shelter.create(name:     "Reptile Room",
+                               address:  "2364 Desert Lane",
+                               city:     "Denver",
+                               state:    "CO",
+                               zip:      "80211")
+
+    visit '/shelters'
+
+    expect(page).to have_content("Reptile Room")
+    expect(page).to have_link('Edit')
+    expect(page).to have_link('Create New')
+  end
+end


### PR DESCRIPTION
Completed User Story 13, Shelter Update From Shelter Index Page

As a visitor
When I visit the shelter index page
Next to every shelter, I see a link to edit that shelter's info
When I click the link
I should be taken to that shelters edit page where I can update its information just like in User Story 5

Test added for User Story 13 and passing
Test coverage 100%