### PR TITLE
usability/user-story-16

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ When I click the link
 I should be taken to that pets edit page where I can update its information just like in User Story 11
 ```
 ```
-[ ] done
+[x] done
 
 User Story 16, Pet Delete From Pets Index Page
 

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -15,6 +15,11 @@
       <h3>Age (approx): <%= pet.age %></h3>
       <h3>Sex: <%= pet.sex %></h3>
       <h3>Shelter: <%= pet.shelter.name %></h3>
-      <a href="/pets/<%= pet.id %>/edit" class='btn btn-info' role='button'>Edit</a><br>
+      <form action='/pets/<%= pet.id %>' method='POST'>
+        <a href="/pets/<%= pet.id %>/edit" class='btn btn-info' role='button'>Edit</a>
+        <input type='hidden' name='authenticity_token' value='<%= form_authenticity_token %>'>
+        <input type='hidden' name='_method' value='DELETE'>
+        <input type="submit" class="btn btn-info" value="Delete"/>
+      </form>
     <% end %>
 <% end %>

--- a/spec/features/usability/user_can_delete_pet_from_pet_index_spec.rb
+++ b/spec/features/usability/user_can_delete_pet_from_pet_index_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "pet index page", type: :feature do
+  it "can delete pet from pet index" do
+
+    shelter_1 = Shelter.create(name:     "Reptile Room",
+                               address:  "2364 Desert Lane",
+                               city:     "Denver",
+                               state:    "CO",
+                               zip:      "80211")
+
+    pet_1 = Pet.create(image: "https://cdn.shopify.com/s/files/1/0341/4893/products/joorvl5fxa7oxccvhj72.jpg?v=1553159130",
+                       name:  "Alfredo",
+                       desc:  "I'm a white ball python named Alfredo!",
+                       age:   "4",
+                       sex:   "female",
+                       status:"adoptable",
+                       shelter_id: shelter_1.id)
+
+    visit "/pets"
+
+    expect(page).to have_button('Delete')
+
+    click_button 'Delete'
+
+    expect(current_path).to eq('/pets')
+    # expect(page.not_to find("#img-#{pet_1.id}")['src']).to have_content "#{pet_1.image}"
+    expect(page).not_to have_content(pet_1.name)
+    expect(page).not_to have_content(pet_1.age)
+    expect(page).not_to have_content(pet_1.sex)
+    end
+end


### PR DESCRIPTION
# Description

## Type of change: Complete User Story 16, Pet Delete From Pets Index Page

As a visitor
When I visit the pets index page or a shelter pets index page
Next to every pet, I see a link to delete that pet
When I click the link
I should be taken to the pets index page where I no longer see that pet

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
