### PR TITLE
extensions/user-story-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ I see a count of the number of pets at this shelter
 ```
 
 ```
-[ ] done
+[x] done
 
 User Story 24, Adoptable Pets Display First
 

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -8,4 +8,7 @@ class Pet < ApplicationRecord
                         :sex,
                         :status
 
+  def self.pet_order
+    order(:status)
+  end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -15,4 +15,8 @@ class Shelter < ApplicationRecord
     pets.count
   end
 
+  def pet_order
+    pets.order(:status)
+  end
+
 end

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Pets</h1>
 
-<% @pets.each do |pet| %>
+<% @pets.pet_order.each do |pet| %>
   <section id="<%= pet.id %>-section">
   <br><img src=<%= pet.image %> class="img-thumbnail" id="img-<%= pet.id %>"></img>
   <h3>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'shelter-link' %></h3>

--- a/app/views/shelters/pets.html.erb
+++ b/app/views/shelters/pets.html.erb
@@ -1,8 +1,8 @@
 
-<h3>Pets at <%= link_to "#{@shelter.name}", "/shelters/#{@shelter.id}", class: 'shelter-link' %>: <%= @shelter.pet_count%></h3>
+<h3>All Pets at <%= link_to "#{@shelter.name}", "/shelters/#{@shelter.id}", class: 'shelter-link' %>: <%= @shelter.pet_count%></h3>
 
 
-  <% @shelter.adoptable_pets.each do |pet| %>
+  <% @shelter.pet_order.each do |pet| %>
     <section id="<%= pet.id %>-section">
     <img src=<%= pet.image %> class="img-thumbnail" id="img-<%= pet.id %>"></img>
     <h3>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'shelter-link' %></h3>

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,6 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Pet, type: :model do
+  before(:each) do
+    @shelter_1 = Shelter.create(name:     "Reptile Room",
+                               address:  "2364 Desert Lane",
+                               city:     "Denver",
+                               state:    "CO",
+                               zip:      "80211")
+
+    @pet_1 = Pet.create(image: "https://cdn.shopify.com/s/files/1/0341/4893/products/joorvl5fxa7oxccvhj72.jpg?v=1553159130",
+                       name:  "Alfredo",
+                       desc:  "I'm a white ball python named Alfredo!",
+                       age:   "4",
+                       sex:   "female",
+                       status:"adoptable",
+                       shelter_id: @shelter_1.id)
+
+    @pet_2 = Pet.create(image: "https://www.geek.com/wp-content/uploads/2019/04/pantherchameleon1-625x352.jpg",
+                       name:  "Poppy",
+                       desc:  "I'm a panther chameleon! I am not very social but am fun to look at.",
+                       age:   "2",
+                       sex:   "male",
+                       status:"adoptable",
+                       shelter_id: @shelter_1.id)
+
+   @pet_3 = Pet.create(image:      "http://reptile.guide/wp-content/uploads/2019/02/Bearded-dragon-poop-.jpg",
+                       name:       "Chive",
+                       desc:       "I'm a bearded dragon. I like to hunt and be active during the daytime.",
+                       age:        "5",
+                       sex:        "male",
+                       status:     "pending adoption",
+                       shelter_id: @shelter_1.id)
+  end
+
   describe "validations" do
     it { should validate_presence_of :image }
     it { should validate_presence_of :name }
@@ -12,5 +44,11 @@ RSpec.describe Pet, type: :model do
 
   describe "relationships" do
     it { should belong_to :shelter }
+  end
+
+  describe "methods" do
+    it "should show pets in order first by adoption" do
+      expect(Pet.all.pet_order).to match_array [@pet_1, @pet_2, @pet_3]
+    end
   end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -55,4 +55,11 @@ RSpec.describe Shelter, type: :model do
 
     expect(@shelter_1.pet_count).to eq(3)
   end
+
+  it "can see adoptable pets first before pending_adoption pets" do
+
+    expect(@shelter_1.pet_order).to match_array [@pet_1, @pet_2, @pet_3]
+  end
+
+
 end


### PR DESCRIPTION
# Description

## Type of change: Completed User Story 24, Adoptable Pets Display First

As a visitor
When I visit a shelter pets index or a pets index page
I see adoptable pets listed before pets whose adoption status is pending

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
